### PR TITLE
Convert memoryview to bytes in create_room_from_snapshot

### DIFF
--- a/channels_yroom/channel.py
+++ b/channels_yroom/channel.py
@@ -54,7 +54,7 @@ class YRoomChannelConsumer(AsyncConsumer):
         logger.debug("yroom connect, no room yet %s %s", room_name, conn_id)
         storage = self.get_storage(room_name)
         logger.debug("Using yroom storage %s of %s", storage, self.storages)
-        snapshot = await storage.get_snapshot(room_name)
+        snapshot = bytes(await storage.get_snapshot(room_name))
         logger.debug("Found snapshot %s", snapshot)
         if snapshot:
             logger.debug("yroom connect, snapshot found %s %s", room_name, snapshot)

--- a/channels_yroom/storage.py
+++ b/channels_yroom/storage.py
@@ -49,7 +49,7 @@ class YDocDatabaseStorage(YDocStorage):
         return await get_db_snapshot(name)
 
     async def save_snapshot(self, name: str, data: bytes) -> None:
-        return await save_db_snapshot(name, data)
+        await save_db_snapshot(name, data)
 
 
 storage_cache = {}


### PR DESCRIPTION
# Background

When the `create_room_from_snapshot` function is triggered and the snapshot is retrieved, it comes back from the DB as a `memoryview` rather than a `bytes` object. These objects are mostly compatible but not always and something that happens in `room_manager.connect_with_data` requires a `bytes` specifically. We were getting `Caught exception: argument 'data': 'bytes' object cannot be interpreted as an integer` every time from the `connect_with_data` call. The wrapping `bytes()` call duplicates the memory, which is slightly inefficient, but worth it to solve the bug.

Separately, I removed a return statement to match the annotated types.

# Repro

For us, these repro steps worked:

1. Configure everything with a DB storage using a PosgreSQL DB
2. Run a server and the yroom worker
3. Start a websocket client and ensure it is connected
4. Restart the yroom worker but maintain the client <> server websocket connection
5. Do something on the client

This should cause the worker to attempt to restore from snapshot and then trigger the `'bytes' object cannot be interpreted as an integer` exception.