### PR TITLE
Autosave Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased - 8.9.2023
+
+- Optional autosaving per room after a certain period of editing inactivity
+
 ## v0.0.6 – 18.5.2023
 
 - Restructure `yroom` worker to be not ASGI based

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine as jsbuilder
+FROM node:20-alpine as jsbuilder
 WORKDIR /usr/src/js
 COPY example/package.json example/package-lock.json /usr/src/js/
 RUN npm install

--- a/channels_yroom/autosave.py
+++ b/channels_yroom/autosave.py
@@ -1,0 +1,83 @@
+import asyncio
+import time
+from asyncio import Task
+from typing import Dict, Callable
+
+from .conf import get_room_settings
+
+
+class Autosave:
+
+    """Automatically save room after some time of non-editing.
+
+    The `nudge()` method can be used to signal editing activity and will
+    schedule a save after `AUTOSAVE_DELAY` many seconds. Subsequent `nudge()`
+    calls will postpone saving. Internally one saver task per room.
+
+    Attributes:
+        consumer: Channel consumer for snapshotting room.
+        time_func: Callable returning a monotonic timestamp.
+        due_times: Next update per room.
+        saver_tasks: Saver tasks per room.
+    """
+
+    def __init__(self, consumer: "YRoomChannelConsumer"):
+        """Args:
+            consumer: YroomConsumer instance used for snapshot_room() saving.
+        """
+        self.consumer = consumer
+        self.time_func: Callable[[], float] = time.perf_counter
+        self.due_times: Dict[str, float] = {}
+        self.saver_tasks: Dict[str, Task] = {}
+
+    def nudge(self, room_name: str) -> None:
+        """Signal editing activity for a room. Schedule autosave in
+        AUTOSAVE_DELAY many seconds. Postpone existing autosavings. Has no
+        effect if AUTOSAVE_DELAY is not defined for this room.
+        """
+        room_settings = get_room_settings(room_name)
+        delay = room_settings["AUTOSAVE_DELAY"]
+        if delay is None:
+            return
+
+        if delay <= 0:
+            raise ValueError("Autosave delay time has to be strictly positive")
+
+        now = self.time_func()
+        self.due_times[room_name] = now + delay
+        if room_name in self.saver_tasks:
+            return
+
+        task = asyncio.create_task(self.snapshot_room_soon(room_name))
+        task.add_done_callback(lambda _task: self.forget(room_name))
+        self.saver_tasks[room_name] = task
+
+    async def snapshot_room_soon(self, room_name: str):
+        """Snapshot room in due time."""
+        while True:
+            now = self.time_func()
+            when = self.due_times[room_name]
+            if now < when:
+                await asyncio.sleep(when - now)
+            else:
+                break
+
+        await self.consumer.snapshot_room(room_name)
+
+    def forget(self, room_name: str) -> None:
+        """Forget about a room."""
+        if room_name in self.saver_tasks:
+            task = self.saver_tasks.pop(room_name)
+            task.cancel()
+
+        self.due_times.pop(room_name, None)
+
+    async def cancel_all(self) -> None:
+        """Cancel all auto saving."""
+        tasks = self.saver_tasks.values()
+        for task in tasks:
+            task.cancel()
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+        self.saver_tasks.clear()
+        self.due_times.clear()

--- a/channels_yroom/autosave.py
+++ b/channels_yroom/autosave.py
@@ -7,17 +7,6 @@ from .conf import get_room_settings
 from .utils import YroomChannelMessage
 
 
-AWARENESS_START = b'{'
-
-
-def non_awareness_payload_size(payload: bytes) -> int:
-    """Payload size without trailing awareness JSON object."""
-    if AWARENESS_START in payload:
-        return payload.index(AWARENESS_START)
-
-    return len(payload)
-
-
 class Autosave:
 
     """Automatically save room after some time of non-editing.
@@ -63,14 +52,6 @@ class Autosave:
         task = asyncio.create_task(self.snapshot_room_soon(room_name))
         task.add_done_callback(lambda _task: self.forget(room_name))
         self.saver_tasks[room_name] = task
-
-    def nudge_if_changed(self, room_message: str, message: YroomChannelMessage) -> None:
-        """Nudge if there was a possible change deduced from the message."""
-        # TODO: There must be a better way?!
-        size = non_awareness_payload_size(message['payload'])
-        changed = size > 15
-        if changed:
-            self.nudge(room_message)
 
     async def snapshot_room_soon(self, room_name: str):
         """Snapshot room in due time."""

--- a/channels_yroom/autosave.py
+++ b/channels_yroom/autosave.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from asyncio import Task
-from typing import Dict, Callable
+from typing import Callable, Dict
 
 from .conf import get_room_settings
 from .utils import YroomChannelMessage
@@ -22,9 +22,9 @@ class Autosave:
         saver_tasks: Saver tasks per room.
     """
 
-    def __init__(self, consumer: "YRoomChannelConsumer"):
+    def __init__(self, consumer: YRoomChannelConsumer):
         """Args:
-            consumer: YroomConsumer instance used for snapshot_room() saving.
+        consumer: YroomConsumer instance used for snapshot_room() saving.
         """
         self.consumer = consumer
         self.time_func: Callable[[], float] = time.perf_counter

--- a/channels_yroom/autosave.py
+++ b/channels_yroom/autosave.py
@@ -1,10 +1,12 @@
 import asyncio
 import time
 from asyncio import Task
-from typing import Callable, Dict
+from typing import TYPE_CHECKING, Callable, Dict
 
 from .conf import get_room_settings
-from .utils import YroomChannelMessage
+
+if TYPE_CHECKING:
+    from .consumer import YRoomChannelConsumer
 
 
 class Autosave:

--- a/channels_yroom/autosave.py
+++ b/channels_yroom/autosave.py
@@ -4,6 +4,18 @@ from asyncio import Task
 from typing import Dict, Callable
 
 from .conf import get_room_settings
+from .utils import YroomChannelMessage
+
+
+AWARENESS_START = b'{'
+
+
+def non_awareness_payload_size(payload: bytes) -> int:
+    """Payload size without trailing awareness JSON object."""
+    if AWARENESS_START in payload:
+        return payload.index(AWARENESS_START)
+
+    return len(payload)
 
 
 class Autosave:
@@ -51,6 +63,14 @@ class Autosave:
         task = asyncio.create_task(self.snapshot_room_soon(room_name))
         task.add_done_callback(lambda _task: self.forget(room_name))
         self.saver_tasks[room_name] = task
+
+    def nudge_if_changed(self, room_message: str, message: YroomChannelMessage) -> None:
+        """Nudge if there was a possible change deduced from the message."""
+        # TODO: There must be a better way?!
+        size = non_awareness_payload_size(message['payload'])
+        changed = size > 15
+        if changed:
+            self.nudge(room_message)
 
     async def snapshot_room_soon(self, room_name: str):
         """Snapshot room in due time."""

--- a/channels_yroom/autosave.py
+++ b/channels_yroom/autosave.py
@@ -24,7 +24,7 @@ class Autosave:
         saver_tasks: Saver tasks per room.
     """
 
-    def __init__(self, consumer: YRoomChannelConsumer):
+    def __init__(self, consumer: 'YRoomChannelConsumer'):
         """Args:
         consumer: YroomConsumer instance used for snapshot_room() saving.
         """

--- a/channels_yroom/autosave.py
+++ b/channels_yroom/autosave.py
@@ -24,7 +24,7 @@ class Autosave:
         saver_tasks: Saver tasks per room.
     """
 
-    def __init__(self, consumer: 'YRoomChannelConsumer'):
+    def __init__(self, consumer: "YRoomChannelConsumer"):
         """Args:
         consumer: YroomConsumer instance used for snapshot_room() saving.
         """

--- a/channels_yroom/channel.py
+++ b/channels_yroom/channel.py
@@ -6,6 +6,7 @@ from typing import Optional
 from channels.consumer import AsyncConsumer
 from yroom import YRoomClientOptions, YRoomManager, YRoomMessage
 
+from .autosave import Autosave
 from .conf import get_room_prefix, get_room_settings, get_settings
 from .storage import YDocStorage, get_ydoc_storage
 from .utils import YroomChannelMessage, YroomChannelRPCMessage
@@ -18,6 +19,7 @@ class YRoomChannelConsumer(AsyncConsumer):
         self.room_manager: YRoomManager = YRoomManager(get_settings())
         self.cleanup_tasks = {}
         self.storages: dict[str, YDocStorage] = {}
+        self.autosave = Autosave(consumer=self)
 
     def get_storage(self, room_name):
         prefix = get_room_prefix(room_name)
@@ -76,6 +78,7 @@ class YRoomChannelConsumer(AsyncConsumer):
         result = self.room_manager.handle_message(
             room_name, conn_id, message["payload"], options
         )
+        self.autosave.nudge_if_changed(room_name, message)
         await self.respond(result, room_name=room_name, channel_name=channel_name)
 
     @asynccontextmanager
@@ -183,6 +186,7 @@ class YRoomChannelConsumer(AsyncConsumer):
         if room_name in self.cleanup_tasks:
             self.cleanup_tasks[room_name].cancel()
 
+        self.autosave.forget(room_name)
         task = asyncio.create_task(self.remove_room_soon(room_name))
         self.cleanup_tasks[room_name] = task
         task.add_done_callback(lambda _task: self.cleanup_tasks.pop(room_name, None))
@@ -218,6 +222,7 @@ class YRoomChannelConsumer(AsyncConsumer):
 
     async def shutdown(self, message) -> None:
         logger.info("Shutdown event received")
+        await self.autosave.cancel_all()
         cleanup_tasks = list(self.cleanup_tasks.values())
         for task in cleanup_tasks:
             task.cancel()

--- a/channels_yroom/conf.py
+++ b/channels_yroom/conf.py
@@ -9,6 +9,7 @@ DEFAULTS = {
     "PROTOCOL_VERSION": 1,
     "PROTOCOL_NAME_PREFIX": False,
     "SERVER_START_SYNC": True,
+    "AUTOSAVE_DELAY": None,  # None for disabled or in strictly positive seconds
 }
 
 

--- a/channels_yroom/models.py
+++ b/channels_yroom/models.py
@@ -8,7 +8,7 @@ class YDocUpdateManager(models.Manager):
         try:
             result = self.get(name=name).data
             if not isinstance(result, bytes):
-                # Postgres returns memoryview
+                # Postgres on psycopg2 returns memoryview
                 return bytes(result)
             return result
         except YDocUpdate.DoesNotExist:

--- a/channels_yroom/utils.py
+++ b/channels_yroom/utils.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import Any, List, Optional, TypedDict
 
+from yroom import YRoomClientOptions
+
 
 class YroomChannelResponse(TypedDict):
     type: str
@@ -23,6 +25,7 @@ class _YroomChannelMessage(TypedDict):  # implicitly total=True
 
 class YroomChannelMessage(_YroomChannelMessage, total=False):
     payload: bytes
+    options: Optional[YRoomClientOptions]
 
 
 class YroomChannelRPCMessage(TypedDict):

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -36,7 +36,6 @@ Default: `30` (in seconds). When the last client disconnects the worker will kee
 ### `"STORAGE_BACKEND"`
 Default: `"channels_yroom.storage.YDocDatabaseStorage"`. Storage backend to use.
 
-
 ### `"PROTOCOL_VERSION"`
 Default: `1`. Yjs protocol encoder/decoder version to use. Currently untested but also possible value is `2`.
 
@@ -45,3 +44,6 @@ Default: `False`. Whether to read and add a string prefix to the network protoco
 
 ### `"SERVER_START_SYNC"`
 Default: `True`. Whether the server sends a sync request and awareness update on connect.
+
+### `"AUTOSAVE_DELAY"`
+Default: `None` deactivated. Snapshot room after a period of inactivity. Save after `AUTOSAVE_DELAY` many seconds. Strictly positive delay value. Note that this can lead to redundant saves.

--- a/example/Procfile
+++ b/example/Procfile
@@ -1,0 +1,4 @@
+web: python manage.py runserver
+worker: PYTHONUNBUFFERED=1 RUST_BACKTRACE=1 python manage.py yroom
+frontend: npm run dev
+redis: redis-server

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -7,3 +7,4 @@ django-vite==2.0.2
 channels-yroom==0.0.6
 psycopg[binary]==3.1.8
 whitenoise==6.4.0
+honcho==1.1.0

--- a/example/textcollab/consumers.py
+++ b/example/textcollab/consumers.py
@@ -1,3 +1,7 @@
+from urllib.parse import parse_qs
+
+from yroom import YRoomClientOptions
+
 from channels_yroom.consumer import YroomConsumer
 
 
@@ -5,10 +9,22 @@ def get_prosemirror_room_name(room_name: str) -> str:
     return "textcollab.%s" % room_name
 
 
+def get_client_options(scope):
+    params = parse_qs(scope["query_string"])
+    read_only = params["readonly"]
+    return YRoomClientOptions(
+        allow_write=not read_only,
+        allow_write_awareness=not read_only,
+    )
+
+
 class TextCollabConsumer(YroomConsumer):
     def get_room_name(self) -> str:
         room_name = self.scope["url_route"]["kwargs"]["room_name"]
         return get_prosemirror_room_name(room_name)
+
+    async def get_client_options(self) -> YRoomClientOptions:
+        return get_client_options(self.scope)
 
 
 def get_tiptap_room_name(room_name: str) -> str:
@@ -19,3 +35,6 @@ class TipTapConsumer(YroomConsumer):
     def get_room_name(self) -> str:
         room_name = self.scope["url_route"]["kwargs"]["room_name"]
         return get_tiptap_room_name(room_name)
+
+    async def get_client_options(self) -> YRoomClientOptions:
+        return get_client_options(self.scope)

--- a/example/textcollab/templates/textcollab/index.html
+++ b/example/textcollab/templates/textcollab/index.html
@@ -5,38 +5,25 @@
     <title>Text Collaboration Rooms</title>
 </head>
 <body>
-    <p>What Prosemirror text collaboration room would you like to enter?</p>
-    <input id="room-name-input" type="text" size="100"><br>
-    <input id="room-name-submit" type="button" value="Enter">
-
-    <hr/>
-    What TipTap text collaboration room would you like to enter?<br>
-    <input id="room-name-input-tiptap" type="text" size="100"><br>
-    <input id="room-name-submit-tiptap" type="button" value="Enter">
-
+    <p>What text collaboration room would you like to enter?</p>
+    <label>Room name: <input id="room-name-input" type="text" size="100"></label><br>
+    <input id="room-name-submit" type="button" value="Enter Prosemirror room">
+    <input id="room-name-submit-tiptap" type="button" value="Enter TipTap room">
 
     <script>
         document.querySelector('#room-name-input').focus();
-        document.querySelector('#room-name-input').onkeyup = function(e) {
-            if (e.keyCode === 13) {  // enter, return
-                document.querySelector('#room-name-submit').click();
-            }
-        };
+
+        function enterRoom(prefix) {
+            var roomName = document.querySelector('#room-name-input').value;
+            window.location.href = url;
+        }
 
         document.querySelector('#room-name-submit').onclick = function(e) {
-            var roomName = document.querySelector('#room-name-input').value;
-            window.location.pathname = '/prosemirror/' + roomName + '/';
-        };
-
-        document.querySelector('#room-name-input-tiptap').onkeyup = function(e) {
-            if (e.keyCode === 13) {  // enter, return
-                document.querySelector('#room-name-submit-tiptap').click();
-            }
+            enterRoom('prosemirror');
         };
 
         document.querySelector('#room-name-submit-tiptap').onclick = function(e) {
-            var roomName = document.querySelector('#room-name-input-tiptap').value;
-            window.location.pathname = '/tiptap/' + roomName + '/';
+            enterRoom('tiptap');
         };
     </script>
 </body>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = "MIT"
 keywords = []
-authors = [
-  { name = "Stefan Wehrmeyer", email = "mail@stefanwehrmeyer.com" },
-]
+authors = [{ name = "Stefan Wehrmeyer", email = "mail@stefanwehrmeyer.com" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
@@ -22,11 +20,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = [
-  "Django >= 3.2",
-  "channels >= 4.0",
-  "yroom >= 0.0.8",
-]
+dependencies = ["Django >= 3.2", "channels >= 4.0", "yroom >= 0.0.10"]
 dynamic = ["version"]
 
 [project.urls]
@@ -62,26 +56,15 @@ python = ["3.8", "3.9", "3.10", "3.11"]
 [tool.hatch.envs.docs]
 skip-install = true
 detached = true
-dependencies = [
-  "mkdocs",
-  "mkdocstrings[python]",
-  "mkdocs-mermaid2-plugin",
-]
+dependencies = ["mkdocs", "mkdocstrings[python]", "mkdocs-mermaid2-plugin"]
 [tool.hatch.envs.docs.scripts]
-serve = [
-  "mkdocs serve -a 127.0.0.1:8001",
-]
-freeze = [
-  "pip freeze > docs/requirements.txt",
-]
+serve = ["mkdocs serve -a 127.0.0.1:8001"]
+freeze = ["pip freeze > docs/requirements.txt"]
 
 [tool.hatch.envs.lint]
 skip-install = true
 detached = true
-dependencies = [
-  "black",
-  "ruff",
-]
+dependencies = ["black", "ruff"]
 
 [tool.hatch.envs.lint.scripts]
 check = [
@@ -92,24 +75,15 @@ check = [
 [tool.coverage.run]
 branch = true
 parallel = true
-omit = [
-  "channels_yroom/__about__.py",
-]
+omit = ["channels_yroom/__about__.py"]
 
 [tool.coverage.report]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
-]
+exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
 [tool.hatch.envs.e2e]
 skip-install = true
 detached = true
-dependencies = [
-  "pytest",
-  "pytest-playwright",
-]
+dependencies = ["pytest", "pytest-playwright"]
 
 [tool.hatch.envs.e2e.scripts]
 test = "example/run_e2e_tests.sh"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
+
 dependencies = ["Django >= 3.2", "channels >= 4.0", "yroom >= 0.0.10"]
 dynamic = ["version"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,8 @@ class YData:
     DOC_DATA = b"\x01\x01\xe9\xdb\x9a\x90\x01\x00\x04\x01\x04test\x06hello \x00"
     # Sync step one with doc data
     SYNC_STEP_1_DATA = b"\x00\x00\x07\x01\xe9\xdb\x9a\x90\x01\x06"
-    SYNC_STEP_2 = b"\x00\x01\x02\x00\x00"
+    # Sync step two + empty awareness update
+    SYNC_STEP_2 = b"\x00\x01\x02\x00\x00\x01\x01\x00"
     AWARENESS_UPDATE = b"\x01\x01\x00"
     # state as update of a doc {"test": "hello"}
 

--- a/tests/test_autosave.py
+++ b/tests/test_autosave.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest
 
-from channels_yroom.conf import get_room_settings, get_default_room_settings
+from channels_yroom.conf import get_default_room_settings
 from channels_yroom.autosave import Autosave
 
 

--- a/tests/test_autosave.py
+++ b/tests/test_autosave.py
@@ -1,0 +1,116 @@
+import asyncio
+import pytest
+
+from channels_yroom.conf import get_room_settings, get_default_room_settings
+from channels_yroom.autosave import Autosave
+
+
+class FakeChannelConsumer:
+    def __init__(self):
+        self.savedRooms = []
+
+    async def snapshot_room(self, room_name: str):
+        self.savedRooms.append(room_name)
+
+
+def test_autosave_is_turned_off_by_default_and_nuding_has_no_effect():
+    settings = get_default_room_settings()
+
+    assert settings["AUTOSAVE_DELAY"] is None
+
+    autosave = Autosave(consumer=None)
+    autosave.nudge("not_present")
+
+    assert not autosave.due_times
+    assert not autosave.saver_tasks
+
+
+@pytest.mark.django_db
+def test_delay_needs_to_be_strictly_positive(settings):
+    settings.YROOM_SETTINGS = {"invalid": {"AUTOSAVE_DELAY": -1.0}}
+    autosave = Autosave(consumer=None)
+
+    with pytest.raises(ValueError) as e:
+        autosave.nudge("invalid")
+
+    assert "Autosave delay time has to be strictly positive" in str(e.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_nuding_multiple_times_postpones_saving(settings):
+    settings.YROOM_SETTINGS = {
+        "some_room": {"AUTOSAVE_DELAY": 0.1},
+    }
+    consumer = FakeChannelConsumer()
+    autosave = Autosave(consumer)
+
+    autosave.nudge("some_room")
+    await asyncio.sleep(0.05)
+    autosave.nudge("some_room")
+    await asyncio.sleep(0.1)
+
+    await asyncio.gather(*autosave.saver_tasks.values())
+
+    assert consumer.savedRooms == ["some_room"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_faster_autosaving_overtakes_slower_one(settings):
+    settings.YROOM_SETTINGS = {
+        "slow": {"AUTOSAVE_DELAY": 0.1},
+        "fast": {"AUTOSAVE_DELAY": 0.01},
+    }
+    consumer = FakeChannelConsumer()
+    autosave = Autosave(consumer)
+
+    autosave.nudge("slow")
+    autosave.nudge("fast")
+    await asyncio.sleep(0.1)
+
+    await asyncio.gather(*autosave.saver_tasks.values())
+
+    assert consumer.savedRooms == ["fast", "slow"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_forgetting_about_room_aborts_saving_and_is_graceful(settings):
+    settings.YROOM_SETTINGS = {
+        "some_room": {"AUTOSAVE_DELAY": 0.1},
+    }
+    consumer = FakeChannelConsumer()
+    autosave = Autosave(consumer)
+
+    autosave.nudge("some_room")
+    await asyncio.sleep(0.05)
+    autosave.forget("some_room")
+    autosave.forget("some_room")  # Graceful?
+    await asyncio.sleep(0.1)
+
+    await asyncio.gather(*autosave.saver_tasks.values())
+
+    assert consumer.savedRooms == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_canceling_everything(settings):
+    settings.YROOM_SETTINGS = {
+        "some_room": {"AUTOSAVE_DELAY": 0.1},
+        "another_room": {"AUTOSAVE_DELAY": 0.1},
+    }
+    autosave = Autosave(consumer=None)
+
+    autosave.nudge("some_room")
+    autosave.nudge("another_room")
+    tasks = list(autosave.saver_tasks.values())
+
+    await autosave.cancel_all()
+
+    for task in tasks:
+        assert task.cancelled()
+
+    assert not autosave.due_times
+    assert not autosave.saver_tasks

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -301,7 +301,7 @@ async def test_export(settings, yroom_worker):
     result = await proxy.export_map("map")
     assert result == test_map
     result = await proxy.export_xml_element("xml_element")
-    assert result == "<UNDEFINED><p>hello</p>world</UNDEFINED>"
+    assert result == "<xml_element><p>hello</p>world</xml_element>"
 
     # Non-existing elements return their defaults
     result = await proxy.export_text("no-text")
@@ -311,7 +311,6 @@ async def test_export(settings, yroom_worker):
     result = await proxy.export_map("no-map")
     assert result == {}
     result = await proxy.export_xml_element("no-xml_element")
-    # TODO: checkout this weirdness
     assert result == "<no-xml_element></no-xml_element>"
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,53 @@
+import pytest
+
+from channels_yroom.models import YDocUpdate
+from channels_yroom.storage import (
+    YDocDatabaseStorage,
+    YDocMemoryStorage,
+    get_ydoc_storage,
+)
+
+
+@pytest.mark.asyncio
+async def test_memory_storage(settings):
+    settings.YROOM_SETTINGS = {
+        "default": {
+            "STORAGE_BACKEND": "channels_yroom.storage.YDocMemoryStorage",
+        }
+    }
+    storage = get_ydoc_storage("test")
+    assert isinstance(storage, YDocMemoryStorage)
+    assert await storage.get_snapshot("test") is None
+    await storage.save_snapshot("test", b"test") is None
+    assert await storage.get_snapshot("test") == b"test"
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_database_storage(settings):
+    settings.YROOM_SETTINGS = {
+        "default": {
+            "STORAGE_BACKEND": "channels_yroom.storage.YDocDatabaseStorage",
+        }
+    }
+    storage = get_ydoc_storage("test")
+    assert isinstance(storage, YDocDatabaseStorage)
+    assert await storage.get_snapshot("test") is None
+    await storage.save_snapshot("test", b"test") is None
+    assert await storage.get_snapshot("test") == b"test"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_database_storage_model(settings):
+    assert YDocUpdate.objects.all().count() == 0
+
+    upd, created = YDocUpdate.objects.save_snapshot("test", b"test")
+    assert created is True
+    assert str(upd) == "test"
+    assert upd.data == b"test"
+    upd, created = YDocUpdate.objects.save_snapshot("test", b"test2")
+    assert created is False
+    assert str(upd) == "test"
+    assert upd.data == b"test2"
+    assert YDocUpdate.objects.get_snapshot("test") == b"test2"
+    assert YDocUpdate.objects.get_snapshot("not-there") is None


### PR DESCRIPTION
Implementing autosave functionality which snapshots a room after a period of editing inactivity.

**Motivation**

A collaborative document gets stored in a database with additional versioning. It would be nice if the stored snapshots correspond to a *stable* state of the document. That is, in between edits.

**Changes**

A new `AUTOSAVE_DELAY` setting was added which controls the debounce delay per room. This is turned off by default.

`YROOM_SETTINGS = {'my-document': {'AUTOSAVE_DELAY': 10.0}}`

An additional [`Autosave`](https://github.com/atheler/channels-yroom/blob/c1ff4b157eac038b9c3a0f45a548ee6101224413/channels_yroom/autosave.py#L21C11-L21C11) object inside the `YRoomChannelConsumer` handles the debouncing and triggers the snapshots. This object spawns a waiter task for each room similar to the cleanup tasks of `YRoomChannelConsumer`.

**Issue / Open Question**

In order for this to work proper editing messages need to be distinguished from awareness / background messages. Unfortunately I am not familiar enough with the `lib0 encoding` scheme. For now a simple size threshold is in place inside [Autosave.nudge_if_changed()](https://github.com/atheler/channels-yroom/blob/c1ff4b157eac038b9c3a0f45a548ee6101224413/channels_yroom/autosave.py#L67-L73). This needs refinement and I would be grateful for inputs pointing me in the right direction.

**Closing**

Let me know what you think and thanks again to @stefanw for the great work!